### PR TITLE
Support for Watchify. Fix for #1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var path    = require('path'),
-    through = require('through');
+  through = require('through');
 
 module.exports = sourcemapify;
 
@@ -14,9 +14,6 @@ module.exports = sourcemapify;
  */
 function sourcemapify(browserify, options) {
   options = options || browserify._options || {};
-
-  // Create a stream to transform the sourcemap
-  var transformStream = through(write, end);
 
   function write(data) {
     if (options.base) {
@@ -34,12 +31,16 @@ function sourcemapify(browserify, options) {
     this.queue(data);
   }
 
-  function end() {
-    this.queue(null);
-  }
-
   // Add our transform stream to Browserify's "debug" pipeline
   // https://github.com/substack/node-browserify#bpipeline
-  browserify.pipeline.get('debug').push(transformStream);
+  configurePipeline();
+  browserify.on('reset', function(){
+    configurePipeline();
+  });
+
+  function configurePipeline() {
+    browserify.pipeline.get('debug').push(new through(write));
+  }
+
   return this;
 }


### PR DESCRIPTION
Following issue #1, I've dug up and managed to get Watchify working.

The problem was the pipeline getting destroyed by Watchify on every `reset` event, so any further change to source files would not have relative paths since Sourcemapify wouldn't have been able to do it's job.

Following that, an other problem cropped up. Once `through` has done it's work, it sets itself to `ended = true` and there is no way (that I found) to reset it to `false`. To remedy this, I'm now creating a new `through` instance every time the pipeline gets set up.

The `end()` method was redundant since through does it automatically so I removed it.
